### PR TITLE
This was a bad bug

### DIFF
--- a/libraries/colorKmeans.js
+++ b/libraries/colorKmeans.js
@@ -8,15 +8,15 @@ Naive k-means. It is fast enough even for large images
 
 function colorKmeans(colors, numClusters) {
     let centroids = []
-    let newCentroids = Array(numClusters)
     for (let i = 0; i < numClusters; i++) {
         let index = Math.floor(Math.random() * colors.length)
         centroids.push(colors[index])
     }
-    let assignments = Array(numClusters)
-    for (let i = 0; i < assignments.length; i++) assignments[i] = []
-
+    let assignments
     for (let k = 0; k < 10; k++) {
+        assignments = Array(centroids.length)
+        let newCentroids = []
+        for (let i = 0; i < assignments.length; i++) assignments[i] = []
         let sumDist = 0
         for (let col of colors) {
             let minn = 255 * 3
@@ -33,22 +33,29 @@ function colorKmeans(colors, numClusters) {
             }
             assignments[minIndex].push(col)
         }
-
+        let remainingCentroids = []
         for (let c = 0; c < assignments.length; c++) {
-            if (assignments[c].length > 0)
-                newCentroids[c] = averageColor(assignments[c])
-        }
+            if (assignments[c].length > 0) {
+                remainingCentroids.push(centroids[c])
 
-        for (let c = 0; c < centroids.length; c++) {
-            let [cr, cg, cb] = centroids[c]
+            }
+        }
+        for (let c = 0; c < assignments.length; c++) {
+            if (assignments[c].length > 0) {
+                newCentroids.push(averageColor(assignments[c]))
+            }
+        }
+        for (let c = 0; c < remainingCentroids.length; c++) {
+            let [cr, cg, cb] = remainingCentroids[c]
             let [r, g, b] = newCentroids[c]
 
             sumDist += Math.abs(cr - r) + Math.abs(cg - g) + Math.abs(cb - b)
-            centroids[c][0] = r
-            centroids[c][1] = g
-            centroids[c][2] = b
-            centroids[c][3] = assignments[c].length
+            remainingCentroids[c][0] = r
+            remainingCentroids[c][1] = g
+            remainingCentroids[c][2] = b
+            remainingCentroids[c][3] = assignments[c].length
         }
+        centroids = remainingCentroids
 
         if (sumDist < 100) {
             break;
@@ -57,7 +64,7 @@ function colorKmeans(colors, numClusters) {
     let closestColors = []
     for (let c = 0; c < centroids.length; c++) {
         let minDist = 3 * 255
-        let closestColor
+        let closestColor = centroids[c]
         let [cr, cg, cb] = centroids[c]
         for (let col of assignments[c]) {
             let [r, g, b] = col

--- a/palette/palette.js
+++ b/palette/palette.js
@@ -17,9 +17,7 @@ import {
 } from '../libraries/colorKmeans.js'
 
 
-// Simple and non-optimised (no hashlife) version of Conway's Game of Life. You
-// can control cell size with i (increase) and d (decrease). Use c to toggle an
-// overlay with the current cell size
+// Naive k-means to find dominant colours. It will adjust number of clusters in case of problems (i.e. empty clusters). 
 
 const sketch = (s) => {
 
@@ -27,7 +25,8 @@ const sketch = (s) => {
     let gui
     let numClusters = 6
     let colors = [],
-        centroids, closeColors, withText = false, kmeans=false
+        centroids, closeColors, withText = false,
+        kmeans = false
     let cutout, imageW, imageH, canvas
 
     s.preload = () => {
@@ -126,7 +125,7 @@ const sketch = (s) => {
 
     function drawRectangles() {
         let c
-        let ht = s.int(imageH / (1.0 * numClusters))
+        let ht = s.int(imageH / (1.0 * centroids.length))
         centroids.sort((a, b) => a[3] - b[3])
         for (c = 0; c < centroids.length - 1; c++) {
             let [r, g, b, k] = kmeans ? centroids[c] : closeColors[c]
@@ -139,8 +138,7 @@ const sketch = (s) => {
     }
 
     function drawCentroids() {
-        let c
-        [centroids, closeColors] = colorKmeans(colors, numClusters)
+        let c[centroids, closeColors] = colorKmeans(colors, numClusters)
         drawRectangles()
     }
 
@@ -169,7 +167,7 @@ const sketch = (s) => {
         })
 
         let kmeansStates = ["centroids", "close color"]
-        let kmeansString = new String(() => kmeansStates[kmeans+0])
+        let kmeansString = new String(() => kmeansStates[kmeans + 0])
         let kmeansControl = new Control([A],
             "cluster centroid?", kmeansString)
 


### PR DESCRIPTION
For images with few colours (THIS IS FINE) the algorithm would fail due
to having clusters with 0 items. Changed a bit the code so that the
number of clusters is adjusted during iteration. A better way would
have been to adjust initial centroids to be "different enough" but
that risks infinite loops anyway. This at least works "as expected".
Press R if you don't see enough colours!